### PR TITLE
Improve Hello World printing demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Here's how you can flash the firmware on DevTerm(A06 or CM4) or a PC running Ubu
 ## Thermal Printer Testing Commands
 
 * How to print "Hello World".  
-`echo "hello world\n\n\n\n\n\n\n\n\n\n" > /tmp/DEVTERM_PRINTER_IN`
+`printf "hello world\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n" > /tmp/DEVTERM_PRINTER_IN`
 
 * How to print a self test page.  
 `echo -en "\x12\x54" >  /tmp/DEVTERM_PRINTER_IN`


### PR DESCRIPTION
As is the first printing demo outputs literally `\n\n\n\n` characters onto the paper. Would have needed `echo -e` to work properly but `printf` generally better so went with that for a more instructive example.

Also adds a few more newlines to get text into view and more ready to be torn off at default printing size on my DevTerm.